### PR TITLE
#72 fix for c# int properties that are string in json

### DIFF
--- a/JsonSrcGen.Inputs/JsonSpanExtensions.cs
+++ b/JsonSrcGen.Inputs/JsonSpanExtensions.cs
@@ -273,6 +273,8 @@ namespace JsonSrcGen
                 case 'n':
                     value = null;
                     return json.Slice(4);
+                case '\"':
+                    throw new InvalidJsonException("Expected int property but found string");
             }
 
             int afterIntIndex = 0;
@@ -314,6 +316,8 @@ namespace JsonSrcGen
                     case '\n':
                     case '\r':
                         continue;
+                    case '\"':
+                        throw new InvalidJsonException("Expected int property but found string");
                     case '-':
                         neg = true;
                         pos++;

--- a/JsonSrcGen.Inputs/JsonUtf8SpanExtensions.cs
+++ b/JsonSrcGen.Inputs/JsonUtf8SpanExtensions.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 #nullable enable
 namespace JsonSrcGen
 {
-    internal static class JsonUtf8SpanExtensions 
+    internal static class JsonUtf8SpanExtensions
     {
         public static ReadOnlySpan<byte> Read(this ReadOnlySpan<byte> json, out bool value)
         {
@@ -57,9 +57,9 @@ namespace JsonSrcGen
                 var character = json[index];
                 if (character >= '0' && character <= '9')
                 {
-         				int digit = character - '0';
-                        soFar *= 10;
-                        soFar += digit; 
+                    int digit = character - '0';
+                    soFar *= 10;
+                    soFar += digit;
                 }
                 else
                 {
@@ -273,6 +273,8 @@ namespace JsonSrcGen
                 case (byte)'n':
                     value = null;
                     return json.Slice(4);
+                case (byte)'\"':
+                    throw new InvalidJsonException("Expected int property but found string");
             }
 
             int afterIntIndex = 0;
@@ -314,6 +316,8 @@ namespace JsonSrcGen
                     case (byte)'\n':
                     case (byte)'\r':
                         continue;
+                    case (byte)'\"':
+                        throw new InvalidJsonException("Expected int property but found string");
                     case (byte)'-':
                         neg = true;
                         pos++;
@@ -324,7 +328,7 @@ namespace JsonSrcGen
                 break;
             }
 
-            uint soFar =  json[pos] - 48U;
+            uint soFar = json[pos] - 48U;
             pos++;
             uint val = 0;
 
@@ -334,7 +338,7 @@ namespace JsonSrcGen
                 pos++;
             }
 
-            value = neg ? unchecked(-(int) soFar) : checked((int) soFar);
+            value = neg ? unchecked(-(int)soFar) : checked((int)soFar);
             return json.Slice(pos);
         }
 
@@ -664,7 +668,7 @@ namespace JsonSrcGen
                 }
             }
 
-            Parse:
+        Parse:
 
             int start = index;
             for (; index < json.Length; index++)
@@ -719,7 +723,7 @@ namespace JsonSrcGen
 
             Span<char> twoCharSpan = stackalloc char[2];
             int length = enc.GetChars(json.Slice(0, remainingBytes + 1), twoCharSpan);
-            if(length > 1)
+            if (length > 1)
             {
                 throw new InvalidJsonException("Tried to deserialize to a char but value requires two chars");
             }
@@ -866,7 +870,7 @@ namespace JsonSrcGen
             for (int index = 0; index < json.Length; index++)
             {
                 var value = json[index];
-                if( value == (byte)'{')
+                if (value == (byte)'{')
                 {
                     return json.Slice(index + 1);
                 }
@@ -880,7 +884,7 @@ namespace JsonSrcGen
             for (int index = 0; index < json.Length; index++)
             {
                 var value = json[index];
-                if( value == (byte)':')
+                if (value == (byte)':')
                 {
                     return json.Slice(index + 1);
                 }
@@ -955,7 +959,7 @@ namespace JsonSrcGen
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ReadOnlySpan<byte> ReadToQuote(this ReadOnlySpan<byte> json) 
+        public static ReadOnlySpan<byte> ReadToQuote(this ReadOnlySpan<byte> json)
         {
             for (int index = 0; index < json.Length; index++)
             {

--- a/UnitTests/IntPropertyTests.cs
+++ b/UnitTests/IntPropertyTests.cs
@@ -8,11 +8,11 @@ namespace UnitTests
     [Json]
     public class JsonIntClass
     {
-        public int Age {get;set;}
-        public int Height {get;set;}
-        public int Min {get;set;}
-        public int Max {get;set;}
-        public int Zero {get;set;}
+        public int Age { get; set; }
+        public int Height { get; set; }
+        public int Min { get; set; }
+        public int Max { get; set; }
+        public int Zero { get; set; }
     }
 
     public class IntPropertyTests : IntPropertyTestsBase
@@ -77,7 +77,7 @@ namespace UnitTests
 
         protected abstract ReadOnlySpan<char> FromJson(JsonIntClass value, string json);
 
-        [Test] 
+        [Test]
         public void FromJson_CorrectJsonClass()
         {
             //arrange
@@ -93,6 +93,18 @@ namespace UnitTests
             Assert.That(jsonClass.Min, Is.EqualTo(int.MinValue));
             Assert.That(jsonClass.Max, Is.EqualTo(int.MaxValue));
             Assert.That(jsonClass.Zero, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void FromJson_InvalidStringInsteadOfInt_InvalidJsonException()
+        {
+            //arrange
+            var json = "{\"Age\":42,\"Height\":\"176\",\"Max\":2147483647,\"Min\":-2147483648,\"Zero\":0}";
+            var jsonClass = new JsonIntClass();
+
+            //act
+            //assert
+            Assert.Throws<InvalidJsonException>(() => FromJson(jsonClass, json));
         }
     }
 }

--- a/UnitTests/NullableIntPropertyTests.cs
+++ b/UnitTests/NullableIntPropertyTests.cs
@@ -8,12 +8,12 @@ namespace UnitTests
     [Json]
     public class JsonNullableIntClass
     {
-        public int? Age {get;set;}
-        public int? Height {get;set;}
-        public int? Min {get;set;}
-        public int? Max {get;set;}
-        public int? Zero {get;set;}
-        public int? Null {get;set;}
+        public int? Age { get; set; }
+        public int? Height { get; set; }
+        public int? Min { get; set; }
+        public int? Max { get; set; }
+        public int? Zero { get; set; }
+        public int? Null { get; set; }
     }
 
     public class NullableIntPropertyTests : NullableIntPropertyTestsBase
@@ -95,6 +95,18 @@ namespace UnitTests
             Assert.That(jsonClass.Max, Is.EqualTo(int.MaxValue));
             Assert.That(jsonClass.Zero, Is.EqualTo(0));
             Assert.That(jsonClass.Null, Is.Null);
+        }
+
+        [Test]
+        public void FromJson_InvalidStringInsteadOfInt_InvalidJsonException()
+        {
+            //arrange
+            var json = "{\"Age\":42,\"Height\":\"176\" ,\"Max\":2147483647,\"Min\":-2147483648,\"Null\":null,\"Zero\":0}";
+            var jsonClass = new JsonNullableIntClass();
+
+            //act
+            //assert
+            Assert.Throws<InvalidJsonException>(() => FromJson(jsonClass, json));
         }
     }
 }


### PR DESCRIPTION
Check for " when parsing a number property and an InvalidJsonException, instead of continuing and crashing in some other undefined way, (I saw a overflow exception)